### PR TITLE
All tests now run the spec tests, as well as indented code block added

### DIFF
--- a/src/main/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/ATXHeading.kt
+++ b/src/main/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/ATXHeading.kt
@@ -22,7 +22,7 @@ class ATXHeading private constructor(val headingLevel: Int, indentation: Int, pa
     }
 
     override fun render(): String {
-        return "<h$headingLevel> ${inline.first().render()} </h$headingLevel>\n"
+        return "<h$headingLevel>${inline.first().render()}</h$headingLevel>\n"
     }
     companion object: IStaticMatchable<ATXHeading>{
 

--- a/src/main/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/CodeFence.kt
+++ b/src/main/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/CodeFence.kt
@@ -19,11 +19,7 @@ class CodeFence private constructor(
     parent: Container
 ) : Leaf(indent = indent, parent = parent) {
 
-
-    // everything matches a code fence once opened
-    override fun match(line: String): Boolean {
-        return super.match(line)
-    }
+    //match is just anything until it detects the end
 
     override fun appendLine(line: String) {
         assert(match(line))
@@ -31,7 +27,7 @@ class CodeFence private constructor(
         val trimmed = line.trim()
         val leadingFenceChar = trimmed.countLeadingChar(fenceChar)
         // close if the closing fence block is found
-        if (line.countLeadingSpaces() < indentCheck(indent) && leadingFenceChar >= fenceLength && fenceLength == trimmed.length) {
+        if (line.countLeadingSpaces() < indentCheck(indent) && leadingFenceChar >= fenceLength && leadingFenceChar == trimmed.length) {
             close()
         } else {
             inline.add(InlineString(removeIndent))
@@ -42,7 +38,7 @@ class CodeFence private constructor(
         val builder = StringBuilder()
         with(builder){
             append("<pre>")
-            val infoStringHTML = if(infoString.isNotEmpty()) " class=\"$infoString\"" else ""
+            val infoStringHTML = if(infoString.isNotEmpty()) " class=\"language-${infoString.trim().split(' ').first()}\"" else ""
             append("<code$infoStringHTML>")
             inline.forEach { append("${it.render()}\n") }
             append("</code>")

--- a/src/main/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/IndentedCodeBlock.kt
+++ b/src/main/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/IndentedCodeBlock.kt
@@ -1,0 +1,63 @@
+package com.matt.belisle.commonmark.ast.leafBlocks
+
+import com.matt.belisle.commonmark.ast.*
+import com.matt.belisle.commonmark.ast.containerBlocks.Container
+import com.matt.belisle.commonmark.ast.inlineElements.InlineString
+import java.lang.StringBuilder
+
+
+class IndentedCodeBlock(indent: Int, parent: Container) : Leaf(indent = indent, parent = parent) {
+
+    private var lastNonBlankLine: Int = -1
+
+    override fun match(line: String): Boolean {
+        return super.match(line) && (line.countLeadingSpaces() >= indentCheck(indent) || line.isBlank())
+    }
+
+    // add the line as is, removing the prefixed spaces
+    override fun appendLine(line: String) {
+        inline.add(InlineString(line.removeLeadingChar(' ', indentCheck(indent))))
+
+        if(line.isNotBlank()){
+            lastNonBlankLine = inline.size - 1
+        }
+    }
+    private constructor(line:String, indent: Int, parent: Container):this(indent, parent){
+        appendLine(line)
+    }
+
+    override fun render(): String {
+        val builder = StringBuilder()
+        with(builder) {
+            append("<pre><code>")
+            for (i in 0..lastNonBlankLine) {
+                val inlineString = inline[i]
+                append(inlineString.render())
+//                if(inlineString != inline.last())
+                append('\n')
+            }
+            append("</code></pre>\n")
+        }
+        return builder.toString()
+    }
+
+    companion object: IStaticMatchable<IndentedCodeBlock> {
+
+        override val canLazyContinue: Boolean = false
+        override val canBeConsecutive: Boolean = true
+        override val canInterruptParagraph: Boolean = false
+
+        override fun parse(line: String, currentOpenBlock: Block, indentation: Int, parent: Container): IndentedCodeBlock {
+            // must be able to match to parse the line
+            assert(this.match(line, currentOpenBlock, indentation))
+            //remove leading and trailing spaces and return a new paragraph
+            return IndentedCodeBlock(line, indentation, parent)
+        }
+
+        // this will be the match to open a new paragraph block
+        override fun match(line: String, currentOpenBlock: Block, indentation: Int): Boolean {
+            return  line.countLeadingSpaces() >= indentCheck(indentation) && line.isNotBlank()
+        }
+
+    }
+}

--- a/src/main/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/ThematicBreak.kt
+++ b/src/main/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/ThematicBreak.kt
@@ -40,11 +40,13 @@ class ThematicBreak private constructor(val thematicBreakChar: Char, parent: Con
         }
 
         override fun match(line: String,currentOpenBlock: Block, indentation: Int): Boolean {
-            return line.countLeadingSpaces() < indentCheck(indentation) && getThematicCharacter(line).second
+            val (thematicChar, match, count) = getThematicCharacter(line)
+            // last check should be taken as a setext
+            return line.countLeadingSpaces() < indentCheck(indentation) && match && !(currentOpenBlock is Paragraph && thematicChar == '-' && line.trim().length == count)
         }
 
         // iterates through the line and gets the character that the thematic break uses , '-' '_' '*'
-        private fun getThematicCharacter(line: String): Pair<Char?, Boolean> {
+        private fun getThematicCharacter(line: String): Triple<Char?, Boolean, Int> {
             var char: Char? = null
             var count = 0
             line.forEach {
@@ -52,7 +54,7 @@ class ThematicBreak private constructor(val thematicBreakChar: Char, parent: Con
                     // no op spaces are fine
                 } else if (it != char) {
                     if (char != null || (it != '_' && it != '-' && it != '*')) {
-                        return Pair(null, false)
+                        return Triple(null, false, 0)
                     } else {
                         char = it
                         count++
@@ -61,7 +63,7 @@ class ThematicBreak private constructor(val thematicBreakChar: Char, parent: Con
                     count++
                 }
             }
-            return Pair(char, count > 2)
+            return Triple(char, count > 2, count)
         }
     }
 

--- a/src/main/kotlin/com/matt/belisle/commonmark/parser/BlockParser.kt
+++ b/src/main/kotlin/com/matt/belisle/commonmark/parser/BlockParser.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.KClass
 // containers are the containers that can be parsed to
 class BlockParser(private val leaves: List<IStaticMatchable<out Leaf>>, private val containers: List<KClass<out Container>>) {
 
-    constructor(): this(listOf(ThematicBreak.Companion, ATXHeading.Companion, CodeFence.Companion, Paragraph.Companion, BlankLine.Companion), emptyList())
+    constructor(): this(listOf(IndentedCodeBlock.Companion, ThematicBreak.Companion, ATXHeading.Companion, CodeFence.Companion, Paragraph.Companion, BlankLine.Companion), emptyList())
     fun parse(data: List<String> ): Document{
         val canInterruptParagraph = leaves.filter { it.canInterruptParagraph }
         val document = Document()

--- a/src/main/kotlin/com/matt/belisle/commonmark/parser/CommonMarkParser.kt
+++ b/src/main/kotlin/com/matt/belisle/commonmark/parser/CommonMarkParser.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KClass
 class CommonMarkParser(private val leaves: List<IStaticMatchable<out Leaf>>, private val containers: List<KClass<out Container>>) {
     val blockParser: BlockParser = BlockParser(leaves, containers)
 
-    constructor(): this(listOf(ThematicBreak.Companion, ATXHeading.Companion, CodeFence.Companion, Paragraph.Companion, BlankLine.Companion), emptyList())
+    constructor(): this(listOf(IndentedCodeBlock.Companion, ThematicBreak.Companion, ATXHeading.Companion, CodeFence.Companion, Paragraph.Companion, BlankLine.Companion), emptyList())
     fun parse(data: List<String> ): Document{
         // parse into blocks
         return blockParser.parse(data)

--- a/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/ATXHeadingTest.kt
+++ b/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/ATXHeadingTest.kt
@@ -68,4 +68,10 @@ class ATXHeadingTest: BasicBlockTest() {
         val ATX = ATXHeading.parse(passingString[0].first, this.document, 0, document)
         ATX.appendLine("AHHHH")
     }
+
+    @Test
+    fun specTest(){
+        specTest("ATX headings")
+//        specTest(35)
+    }
 }

--- a/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/BasicBlockTest.kt
+++ b/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/BasicBlockTest.kt
@@ -1,5 +1,6 @@
 package com.matt.belisle.commonmark.ast.leafBlocks
 
+import com.matt.belisle.commonmark.TestCase
 import com.matt.belisle.commonmark.TestCases
 import com.matt.belisle.commonmark.ast.Document
 import com.matt.belisle.commonmark.parser.CommonMarkParser
@@ -11,22 +12,29 @@ abstract class BasicBlockTest {
     internal var document = Document()
 
     fun specTest(type: String){
+        runSpecTest(TestCases.testCases.filter { it.section == type }, false)
+    }
+    fun specTest(example: Int){
+        runSpecTest(TestCases.testCases.filter { it.example == example }, true)
+    }
+
+    private fun runSpecTest(tests : List<TestCase>, singleTest: Boolean){
         var failed = false
-        val tests = TestCases.testCases.filter { it.section == type }
         val parser = CommonMarkParser()
         tests.forEach {
             val rendered = parser.parse(it.markdown.split('\n').dropLast(1)).render()
             //TODO for now keep here as just wanting to see block structure is correct, once inlines started do not have this
-           try{
+            try{
                 Assert.assertEquals(
                     "test ${it.example} Failed\n Parsed: $rendered\nExpected: ${it.html}",
                     it.html,
                     rendered
                 )
             } catch (e: ComparisonFailure){
-               println(e.message!!)
-               failed = true
-           }
+                if(singleTest) throw e
+                println(e.message!!)
+                failed = true
+            }
         }
         assertFalse(failed)
     }

--- a/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/CodeFenceTest.kt
+++ b/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/CodeFenceTest.kt
@@ -14,4 +14,10 @@ class CodeFenceTest: BasicBlockTest(){
         assertEquals(0, codeFence.fenceIndent)
         assertEquals("", codeFence.infoString)
     }
+
+    @Test
+    fun specTest() {
+        specTest("Fenced code blocks")
+        specTest(112)
+    }
 }

--- a/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/IndentedCodeBlockTest.kt
+++ b/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/IndentedCodeBlockTest.kt
@@ -1,0 +1,11 @@
+package com.matt.belisle.commonmark.ast.leafBlocks
+
+import org.junit.Test
+
+class IndentedCodeBlockTest: BasicBlockTest() {
+    @Test
+    fun specTests(){
+        specTest("Indented code blocks")
+//        specTest(85)
+    }
+}

--- a/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/SetextHeadingTest.kt
+++ b/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/SetextHeadingTest.kt
@@ -1,0 +1,11 @@
+package com.matt.belisle.commonmark.ast.leafBlocks
+
+import org.junit.Test
+
+class SetextHeadingTest: BasicBlockTest() {
+    @Test
+    fun specTests(){
+        specTest("Setext headings")
+//        specTest(85)
+    }
+}

--- a/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/ThematicBreakTest.kt
+++ b/src/test/kotlin/com/matt/belisle/commonmark/ast/leafBlocks/ThematicBreakTest.kt
@@ -59,4 +59,9 @@ class ThematicBreakTest: BasicBlockTest() {
 
     @Test(expected = AssertionError::class)
     fun doesntParse() = failingString.forEach { ThematicBreak.parse(it, this.document, 0, document) }
+
+    @Test
+    fun specTest(){
+        specTest("Thematic breaks")
+    }
 }


### PR DESCRIPTION
Failing tests are because of missing container blocks, or missing inlines